### PR TITLE
WhiteList implementation bug fixing.

### DIFF
--- a/framework/src/org/apache/cordova/Config.java
+++ b/framework/src/org/apache/cordova/Config.java
@@ -78,6 +78,10 @@ public class Config {
             return;
         }
 
+        // Add "file://" and "content://" schemas to access control list by default. 
+        whitelist.addWhiteListEntry("file://*", false);
+        whitelist.addWhiteListEntry("content://*", false);
+        
         XmlResourceParser xml = action.getResources().getXml(id);
         int eventType = -1;
         while (eventType != XmlResourceParser.END_DOCUMENT) {


### PR DESCRIPTION
There are 22 test cases from cordova-mobile-spec failed, due to
the regular expressions(regex) for access pattern of WhiteList has bugs:
1.  Need to change string "_" to "._" for regex.
2.  Need to consider the "user:pass@" in regex.
3.  Need to consider the "subfolder" for domain in regex.
4.  Need to avoid evil url in regex.

And also add "file://" and "content://" schemas to the whitelist by default.

BUG=https://github.com/otcshare/cordova-xwalk-android/issues/15
