### PR TITLE
Fix file transfer plugin crash issue.

### DIFF
--- a/framework/src/org/apache/cordova/CordovaPlugin.java
+++ b/framework/src/org/apache/cordova/CordovaPlugin.java
@@ -27,6 +27,7 @@ import org.json.JSONException;
 
 import android.content.Intent;
 import android.net.Uri;
+import android.webkit.CookieSyncManager;
 
 /**
  * Plugins must extend this class and override one of the execute methods.
@@ -44,6 +45,7 @@ public class CordovaPlugin {
         assert this.cordova == null;
         this.cordova = cordova;
         this.webView = webView;
+        CookieSyncManager.createInstance(cordova.getActivity());
     }
 
     /**


### PR DESCRIPTION
The root cause is the File Transfer API implementation leverages the android.webkit.CookieManager.
But trying to getinstance() of CookieManager before the webview isn't instantiated would cause crash.
In the cordova with xwalk backend solution, there doesn't exist webview.

According to android official document:
http://developer.android.com/reference/android/webkit/CookieManager.html#getInstance%28%29
We need to call "CookieSyncManager.createInstance(Context)" first.

Known issue:
This only fix crash issue, the cookie support is faking.
Still need to bridge xwalk cookie manager with default android.webkit.CookieManager.

BUG=https://github.com/otcshare/cordova-xwalk-android/issues/13
