### PR TITLE
Fix splashscreen no effect when missing to set "splashscreen".

### DIFF
--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -1050,8 +1050,9 @@ public class CordovaActivity extends Activity implements CordovaInterface {
                 root.setBackgroundColor(that.getIntegerProperty("backgroundColor", Color.BLACK));
                 root.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.FILL_PARENT,
                         ViewGroup.LayoutParams.FILL_PARENT, 0.0F));
-                root.setBackgroundResource(that.splashscreen);
-                
+                if (that.splashscreen != 0) {
+                    root.setBackgroundResource(that.splashscreen);
+                }
                 // Create and show the dialog
                 splashDialog = new Dialog(that, android.R.style.Theme_Translucent_NoTitleBar);
                 // check to see if the splash screen should be full screen


### PR DESCRIPTION
In the CordovaActivity.java, it requires to set "splashscreen"
property for customized splashscreen when application want to
leverage cordova's splashscreen API. The "splashscreen" property
is set to 0 by default.

But from the android official document for  setBackgroundResource API
(http://developer.android.com/reference/android/view/View.html),
it shows "The resource should refer to a Drawable object or 0 to remove the background."
Which means there would be no splashscreen effect even there do
exist splashdialog, even splashscreen API has been called.

The activity of cordova-mobile-spec is auto generated from the bash, which forget
to set the "splashscreen", but it calls the cordova's splashscreen API.

This patch is to add check before setBackgroundResource API, if its argument
is euqal to 0, would skip this call this API.

BUG=https://github.com/otcshare/cordova-xwalk-android/issues/12
