### PR TITLE
Copy assets from xwalk core library to cordova app

### DIFF
--- a/bin/create
+++ b/bin/create
@@ -112,6 +112,9 @@ fi
 cp -r "$BUILD_PATH"/bin/templates/project/assets "$PROJECT_PATH"
 cp -r "$BUILD_PATH"/bin/templates/project/res "$PROJECT_PATH"
 
+# copy assets from xwalk core library
+cp -r "$XWALK_LIBRARY_PATH"/assets "$PROJECT_PATH"
+
 # copy cordova.js, cordova.jar and res/xml
 if [ -d "$BUILD_PATH"/framework ]
 then


### PR DESCRIPTION
Android library project doesn't handle assets according to
http://developer.android.com/tools/projects/index.html.

BUG=Input tag crashes cordova app
