### PR TITLE
Use OnlineEvent as bridge mode for message passing

### DIFF
--- a/framework/src/org/apache/cordova/NativeToJsMessageQueue.java
+++ b/framework/src/org/apache/cordova/NativeToJsMessageQueue.java
@@ -36,7 +36,7 @@ public class NativeToJsMessageQueue {
     private static final String LOG_TAG = "JsMessageQueue";
 
     // This must match the default value in incubator-cordova-js/lib/android/exec.js
-    private static final int DEFAULT_BRIDGE_MODE = 1;
+    private static final int DEFAULT_BRIDGE_MODE = 2;
     
     // Set this to true to force plugin results to be encoding as
     // JS instead of the custom format (useful for benchmarking).


### PR DESCRIPTION
It fixes the failures in file tests. The file API MUST use this mode since it
needs to encode/decode the binary data between JavaScript and Java.
