### PR TITLE
Move the xwalk_core_library path into framework

### DIFF
--- a/bin/create
+++ b/bin/create
@@ -34,7 +34,7 @@ then
 fi
 
 BUILD_PATH="$( cd "$( dirname "$0" )/.." && pwd )"
-XWALK_LIBRARY_REL_PATH="../xwalk_core_library"
+XWALK_LIBRARY_REL_PATH="framework/xwalk_core_library"
 XWALK_LIBRARY_PATH="$BUILD_PATH"/"$XWALK_LIBRARY_REL_PATH"
 VERSION=$(cat "$BUILD_PATH"/VERSION)
 

--- a/framework/project.properties
+++ b/framework/project.properties
@@ -14,4 +14,4 @@ target=android-17
 apk-configurations=
 renderscript.opt.level=O0
 android.library=true
-android.library.reference.1=../../xwalk_core_library
+android.library.reference.1=xwalk_core_library


### PR DESCRIPTION
It aims to optimize the CLI workflow. It requires the buildbot copies the
xwalk_core_library into framework when producing cordova.tar.gz.

With these changes, CLI users will not download xwalk_core_library separately.
