### PR TITLE
Add xwalk extension system to cordova-xwalk-android.

### DIFF
--- a/framework/src/org/xwalk/runtime/CordovaXWalkCoreExtensionBridge.java
+++ b/framework/src/org/xwalk/runtime/CordovaXWalkCoreExtensionBridge.java
@@ -1,0 +1,18 @@
+// Copyright (c) 2013 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.runtime;
+
+import org.xwalk.runtime.extension.XWalkExtension;
+
+/**
+ * This class is a public wrapper for XWalkCoreExtensionBridge.
+ */
+public class CordovaXWalkCoreExtensionBridge extends XWalkCoreExtensionBridge {
+
+    public CordovaXWalkCoreExtensionBridge(XWalkExtension extension,
+            XWalkRuntimeViewProvider provider) {
+        super(extension, provider);
+    }
+}


### PR DESCRIPTION
Changes in this patch:
1. Implement XWalkRuntimeViewProvider interface for CordovaWebView.
2. Add a public class CordovaXWalkCoreExtensionBridge to provide the
   functionalities of friendly class XWalkCoreExtensionBridge.
