### PR TITLE
Add xwalk_core_library to git ignore path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ framework/assets/www/.DS_Store
 framework/assets/www/cordova-*.js
 framework/assets/www/phonegap-*.js
 framework/libs
+framework/xwalk_core_library
 test/libs
 example
 ./test


### PR DESCRIPTION
Otherwise, buildbot will not pack it into tarball.
