### PR TITLE
Add empty implementation for loadDataForTest in CordovaWebView

### DIFF
--- a/framework/src/org/apache/cordova/CordovaWebView.java
+++ b/framework/src/org/apache/cordova/CordovaWebView.java
@@ -1056,6 +1056,10 @@ public class CordovaWebView extends XWalkView implements XWalkRuntimeViewProvide
     }
 
     @Override
+    public void loadDataForTest(String data, String mimeType, boolean isBase64Encoded) {
+    }
+
+    @Override
     public void setCallbackForTest(Object callback) {
     }
 }


### PR DESCRIPTION
Otherwise, build is blocked for abstract function not implemented.
