### PR TITLE
Implement the destroyExtension interface

### DIFF
--- a/framework/src/org/apache/cordova/CordovaWebView.java
+++ b/framework/src/org/apache/cordova/CordovaWebView.java
@@ -1051,6 +1051,12 @@ public class CordovaWebView extends XWalkView implements XWalkRuntimeViewProvide
     }
 
     @Override
+    public void destroyExtension(XWalkExtension extension) {
+        CordovaXWalkCoreExtensionBridge bridge = (CordovaXWalkCoreExtensionBridge)extension.getRegisteredId();
+        bridge.destroy();
+    }
+
+    @Override
     public String getTitleForTest() {
         return this.getTitle();
     }


### PR DESCRIPTION
It is introduced in XWalkRuntimeViewProvider to destroy the native
resources occupied by extension.
