### PR TITLE
[Android] Refine the test cases for thread safety checking.

### DIFF
--- a/test/src/org/apache/cordova/test/CordovaActivityTest.java
+++ b/test/src/org/apache/cordova/test/CordovaActivityTest.java
@@ -72,12 +72,17 @@ public class CordovaActivityTest extends ActivityInstrumentationTestCase2<Cordov
 
     public void testPauseAndResume()
     {
-        mInstr.callActivityOnPause(testActivity);
-        sleep();
-        assertTrue(testView.isPaused());
-        mInstr.callActivityOnResume(testActivity);
-        sleep();
-        assertFalse(testView.isPaused());
+        testActivity.runOnUiThread(new Runnable() {
+            public void run() {
+                mInstr.callActivityOnPause(testActivity);
+                sleep();
+                assertTrue(testView.isPaused());
+                mInstr.callActivityOnResume(testActivity);
+                sleep();
+                assertFalse(testView.isPaused());
+            }
+        });
+        mInstr.waitForIdleSync();
     }
     
     private void sleep() {

--- a/test/src/org/apache/cordova/test/HtmlNotFoundTest.java
+++ b/test/src/org/apache/cordova/test/HtmlNotFoundTest.java
@@ -56,11 +56,16 @@ public class HtmlNotFoundTest extends ActivityInstrumentationTestCase2<htmlnotfo
 
   public void testUrl()
   {
-      sleep();
-      String good_url = "file:///android_asset/www/htmlnotfound/error.html";
-      String url = testView.getUrl();
-      assertNotNull(url);
-      assertFalse(url.equals(good_url));
+      testActivity.runOnUiThread(new Runnable() {
+          public void run() {
+              sleep();
+              String good_url = "file:///android_asset/www/htmlnotfound/error.html";
+              String url = testView.getUrl();
+              assertNotNull(url);
+              assertFalse(url.equals(good_url));
+          }
+  	  });
+      getInstrumentation().waitForIdleSync();
   }
 
   private void sleep() {

--- a/test/src/org/apache/cordova/test/IFrameTest.java
+++ b/test/src/org/apache/cordova/test/IFrameTest.java
@@ -62,24 +62,34 @@ public class IFrameTest extends ActivityInstrumentationTestCase2 {
   
     public void testIframeDest()
     {
-        testView.sendJavascript("loadUrl('http://maps.google.com/maps?output=embed');");
-        sleep(3000);
-        testView.sendJavascript("loadUrl('index2.html')");
-        sleep(1000);
-        String url = testView.getUrl();
-        assertTrue(url.endsWith("index.html"));
+        testActivity.runOnUiThread(new Runnable() {
+            public void run() {
+                testView.sendJavascript("loadUrl('http://maps.google.com/maps?output=embed');");
+                sleep(3000);
+                testView.sendJavascript("loadUrl('index2.html')");
+                sleep(1000);
+                String url = testView.getUrl();
+                assertTrue(url.endsWith("index.html"));
+            }
+    	});
+    	getInstrumentation().waitForIdleSync();
     }
     
     public void testIframeHistory()
     {
-        testView.sendJavascript("loadUrl('http://maps.google.com/maps?output=embed');");
-        sleep(3000);
-        testView.sendJavascript("loadUrl('index2.html')");
-        sleep(1000);
-        String url = testView.getUrl();
-        testView.backHistory();
-        sleep(1000);
-        assertTrue(url.endsWith("index.html"));
+        testActivity.runOnUiThread(new Runnable() {
+            public void run() {
+                testView.sendJavascript("loadUrl('http://maps.google.com/maps?output=embed');");
+                sleep(3000);
+                testView.sendJavascript("loadUrl('index2.html')");
+                sleep(1000);
+                String url = testView.getUrl();
+                testView.backHistory();
+                sleep(1000);
+                assertTrue(url.endsWith("index.html"));
+            }
+    	});
+    	getInstrumentation().waitForIdleSync();
     }
     
     private void sleep(int timeout) {


### PR DESCRIPTION
Schedule the webview's API called on UI thread, otherwise, that
would cause the RuntimeException. This patch refines two test case
of IFrameTest, one test case of HtmlNotFoundTest and one test case
of CordovaActivityTest.

BUG=https://github.com/otcshare/cordova-xwalk-android/issues/52
