### PR TITLE
Fix "setIntegerProperty("loadUrlTimeoutValue", 200)" not work issue.

### DIFF
--- a/framework/src/org/apache/cordova/CordovaWebView.java
+++ b/framework/src/org/apache/cordova/CordovaWebView.java
@@ -400,7 +400,7 @@ public class CordovaWebView extends XWalkView {
         // Create a timeout timer for loadUrl
         final CordovaWebView me = this;
         final int currentLoadUrlTimeout = me.loadUrlTimeout;
-        final int loadUrlTimeoutValue = Integer.parseInt(this.getProperty("loadUrlTimeoutValue", "20000"));
+        final int loadUrlTimeoutValue = Integer.parseInt(this.getProperty("loadurltimeoutvalue", "20000"));
 
         // Timeout error method
         final Runnable loadError = new Runnable() {


### PR DESCRIPTION
Because CordovaWebView sets/gets the property through the intent, and the
API for getting/setting in the CordovaActivity would unify to lower the property
name, but in the implementation of CordovaWebView, it has its own API
"getProperty" which doesn't lower the property name, so when calling this API
in the CordovaWebView should lower the property name itself first, otherwise, it
would use the default value (second argument) always, and the developer's setting
"super.setIntegerProperty("loadUrlTimeoutValue", 60000);" would never take effection.
