### PR TITLE
Fix that onNewIntent in CordovaWebView should return boolean as in XWalk...

### DIFF
--- a/framework/src/org/apache/cordova/CordovaWebView.java
+++ b/framework/src/org/apache/cordova/CordovaWebView.java
@@ -877,12 +877,15 @@ public class CordovaWebView extends XWalkView {
         }
     }
     
-    public void onNewIntent(Intent intent)
+    @Override
+    public boolean onNewIntent(Intent intent)
     {
+        if (super.onNewIntent(intent)) return true;
         //Forward to plugins
         if (this.pluginManager != null) {
             this.pluginManager.onNewIntent(intent);
         }
+        return false;
     }
     
     public boolean isPaused()


### PR DESCRIPTION
...View

onNewIntent in XWalkView is introduced by Notification API, it needs
return boolean to identify the intent is consumed or not.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1072
