### PR TITLE
Remove copy asset step from create script

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -174,9 +174,6 @@ exports.createProject = function(project_path, package_name, project_name, proje
             // Manually create directories that would be empty within the template (since git doesn't track directories).
             shell.mkdir(path.join(project_path, 'libs'));
 
-            // copy assets from xwalk core library
-            shell.cp('-r', path.join(XWALK_LIBRARY_PATH, 'assets'), project_path);
-
             // copy cordova.js, cordova.jar and res/xml
             shell.cp('-r', path.join(ROOT, 'framework', 'res', 'xml'), path.join(project_path, 'res'));
             copyJsAndLibrary(project_path, use_shared_project, safe_activity_name);


### PR DESCRIPTION
It's not needed anymore, assets from xwalk_core_library
have been moved to res/raw.
