### PR TITLE
Fix the build error due to the rename of package name.

### DIFF
--- a/framework/src/org/apache/cordova/CordovaChromeClient.java
+++ b/framework/src/org/apache/cordova/CordovaChromeClient.java
@@ -40,7 +40,7 @@ import org.xwalk.core.JsResult;
 import android.webkit.ValueCallback;
 //import android.webkit.WebChromeClient;
 import org.xwalk.core.XWalkWebChromeClient;
-import org.xwalk.core.client.XWalkDefaultWebChromeClient;
+import org.xwalk.core.XWalkDefaultWebChromeClient;
 import android.webkit.WebStorage;
 //import android.webkit.WebView;
 import org.xwalk.core.XWalkView;


### PR DESCRIPTION
XWalkDefaultWebChromeClient is moved from org.xwalk.core.client to
org.xwalk.core. Change the package name in Cordova as well.
