### PR TITLE
Remove unused import for SSL error handler.

### DIFF
--- a/framework/src/org/apache/cordova/CordovaWebViewClient.java
+++ b/framework/src/org/apache/cordova/CordovaWebViewClient.java
@@ -47,7 +47,6 @@ import org.chromium.net.NetError;
 import org.xwalk.core.XWalkView;
 import org.xwalk.core.XWalkClient;
 import org.xwalk.core.XWalkHttpAuthHandler;
-import org.xwalk.core.SslErrorHandler;
 
 /**
  * This class is the WebViewClient that implements callbacks for our web view.


### PR DESCRIPTION
SSLErrorHandler was removed in crosswalk so there is no need to
import it in Cordova.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1287
