### PR TITLE
Refactor Cordova container to use the new API defined in Crosswalk.

### DIFF
--- a/framework/src/org/apache/cordova/App.java
+++ b/framework/src/org/apache/cordova/App.java
@@ -168,7 +168,7 @@ public class App extends CordovaPlugin {
      * Clear page history for the app.
      */
     public void clearHistory() {
-        this.webView.clearHistory();
+        this.webView.getNavigationHistory().clear();
     }
 
     /**

--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -470,7 +470,7 @@ public class CordovaActivity extends Activity implements CordovaInterface {
 
         // If loadingDialog property, then show the App loading dialog for first page of app
         String loading = null;
-        if ((this.appView == null) || !this.appView.canGoBack()) {
+        if ((this.appView == null) || !this.appView.getNavigationHistory().canGoBack()) {
             loading = this.getStringProperty("LoadingDialog", null);
         }
         else {
@@ -520,7 +520,7 @@ public class CordovaActivity extends Activity implements CordovaInterface {
      * Clear web history in this web view.
      */
     public void clearHistory() {
-        this.appView.clearHistory();
+        this.appView.getNavigationHistory().clear();
     }
 
     /**
@@ -714,7 +714,7 @@ public class CordovaActivity extends Activity implements CordovaInterface {
     protected void onPause() {
         super.onPause();
         if (this.appView != null)
-            this.appView.onPause();
+            this.appView.onHide();
 
         LOG.d(TAG, "Paused the application!");
 
@@ -753,7 +753,7 @@ public class CordovaActivity extends Activity implements CordovaInterface {
     protected void onResume() {
         super.onResume();
         if (this.appView != null)
-            this.appView.onResume();
+            this.appView.onShow();
         //Reload the configuration
         Config.init(this);
 

--- a/framework/src/org/apache/cordova/CordovaChromeClient.java
+++ b/framework/src/org/apache/cordova/CordovaChromeClient.java
@@ -19,12 +19,13 @@
 package org.apache.cordova;
 
 import org.apache.cordova.CordovaInterface;
-import org.apache.cordova.LOG;
+//import org.apache.cordova.LOG;
 import org.json.JSONArray;
 import org.json.JSONException;
 
-import android.annotation.TargetApi;
+//import android.annotation.TargetApi;
 import android.app.AlertDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
@@ -32,24 +33,16 @@ import android.view.Gravity;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewGroup.LayoutParams;
-import android.webkit.ConsoleMessage;
-//import android.webkit.JsPromptResult;
-//import android.webkit.JsResult;
-import org.xwalk.core.JsPromptResult;
-import org.xwalk.core.JsResult;
 import android.webkit.ValueCallback;
-//import android.webkit.WebChromeClient;
-import org.xwalk.core.XWalkWebChromeClient;
-import org.xwalk.core.XWalkDefaultWebChromeClient;
-import android.webkit.WebStorage;
-//import android.webkit.WebView;
-import org.xwalk.core.XWalkView;
-import org.xwalk.core.XWalkGeolocationPermissions;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 
+import org.xwalk.core.XWalkJavascriptResult;
+import org.xwalk.core.XWalkWebChromeClient;
+import org.xwalk.core.XWalkUIClientImpl;
+import org.xwalk.core.XWalkView;
 /**
  * This class is the WebChromeClient that implements callbacks for our web view.
  * The kind of callbacks that happen here are on the chrome outside the document,
@@ -61,18 +54,12 @@ import android.widget.RelativeLayout;
  * @see CordovaWebViewClient
  * @see CordovaWebView
  */
-public class CordovaChromeClient extends XWalkDefaultWebChromeClient {
+public class CordovaChromeClient extends XWalkUIClientImpl {
 
     public static final int FILECHOOSER_RESULTCODE = 5173;
-    private static final String LOG_TAG = "CordovaChromeClient";
-    private String TAG = "CordovaLog";
-    private long MAX_QUOTA = 100 * 1024 * 1024;
     protected CordovaInterface cordova;
     protected CordovaWebView appView;
 
-    // the video progress view
-    private View mVideoProgressView;
-    
     // File Chooser
     public ValueCallback<Uri> mUploadMessage;
     
@@ -96,6 +83,7 @@ public class CordovaChromeClient extends XWalkDefaultWebChromeClient {
         super(ctx.getActivity(), app);
         this.cordova = ctx;
         this.appView = app;
+        this.appView.setXWalkWebChromeClient(new CordovaWebChromeClient(ctx.getActivity(), app));
     }
 
     /**
@@ -107,6 +95,26 @@ public class CordovaChromeClient extends XWalkDefaultWebChromeClient {
         this.appView = view;
     }
 
+    @Override
+    public boolean onJavascriptModalDialog(XWalkView view, JavascriptMessageType type, String url,
+            String message, String defaultValue, XWalkJavascriptResult result) {
+        switch(type) {
+            case JAVASCRIPT_ALERT:
+                return onJsAlert(view, url, message, result);
+            case JAVASCRIPT_CONFIRM:
+                return onJsConfirm(view, url, message, result);
+            case JAVASCRIPT_PROMPT:
+                return onJsPrompt(view, url, message, defaultValue, result);
+            case JAVASCRIPT_BEFOREUNLOAD:
+                // Reuse onJsConfirm to show the dialog.
+                return onJsConfirm(view, url, message, result);
+            default:
+                break;
+        }
+        assert(false);
+        return false;
+    }
+
     /**
      * Tell the client to display a javascript alert dialog.
      *
@@ -115,8 +123,8 @@ public class CordovaChromeClient extends XWalkDefaultWebChromeClient {
      * @param message
      * @param result
      */
-    @Override
-    public boolean onJsAlert(XWalkView view, String url, String message, final JsResult result) {
+    private boolean onJsAlert(XWalkView view, String url, String message,
+            final XWalkJavascriptResult result) {
         AlertDialog.Builder dlg = new AlertDialog.Builder(this.cordova.getActivity());
         dlg.setMessage(message);
         dlg.setTitle("Alert");
@@ -159,8 +167,8 @@ public class CordovaChromeClient extends XWalkDefaultWebChromeClient {
      * @param message
      * @param result
      */
-    @Override
-    public boolean onJsConfirm(XWalkView view, String url, String message, final JsResult result) {
+    private boolean onJsConfirm(XWalkView view, String url, String message,
+            final XWalkJavascriptResult result) {
         AlertDialog.Builder dlg = new AlertDialog.Builder(this.cordova.getActivity());
         dlg.setMessage(message);
         dlg.setTitle("Confirm");
@@ -214,8 +222,8 @@ public class CordovaChromeClient extends XWalkDefaultWebChromeClient {
      * @param defaultValue
      * @param result
      */
-    @Override
-    public boolean onJsPrompt(XWalkView view, String url, String message, String defaultValue, JsPromptResult result) {
+    private boolean onJsPrompt(XWalkView view, String url, String message, String defaultValue,
+            XWalkJavascriptResult result) {
 
         // Security check to make sure any requests are coming from the page initially
         // loaded in webview and not another loaded in an iframe.
@@ -234,7 +242,7 @@ public class CordovaChromeClient extends XWalkDefaultWebChromeClient {
                 String action = array.getString(1);
                 String callbackId = array.getString(2);
                 String r = this.appView.exposedJsApi.exec(service, action, callbackId, message);
-                result.confirm(r == null ? "" : r);
+                result.confirmWithResult(r == null ? "" : r);
             } catch (JSONException e) {
                 e.printStackTrace();
                 return false;
@@ -245,9 +253,9 @@ public class CordovaChromeClient extends XWalkDefaultWebChromeClient {
         else if (reqOk && defaultValue != null && defaultValue.equals("gap_bridge_mode:")) {
         	try {
                 this.appView.exposedJsApi.setNativeToJsBridgeMode(Integer.parseInt(message));
-                result.confirm("");
+                result.confirmWithResult("");
         	} catch (NumberFormatException e){
-                result.confirm("");
+                result.confirmWithResult("");
                 e.printStackTrace();
         	}
         }
@@ -255,17 +263,17 @@ public class CordovaChromeClient extends XWalkDefaultWebChromeClient {
         // Polling for JavaScript messages 
         else if (reqOk && defaultValue != null && defaultValue.equals("gap_poll:")) {
             String r = this.appView.exposedJsApi.retrieveJsMessages("1".equals(message));
-            result.confirm(r == null ? "" : r);
+            result.confirmWithResult(r == null ? "" : r);
         }
 
         // Do NO-OP so older code doesn't display dialog
         else if (defaultValue != null && defaultValue.equals("gap_init:")) {
-            result.confirm("OK");
+            result.confirmWithResult("OK");
         }
 
         // Show dialog
         else {
-            final JsPromptResult res = result;
+            final XWalkJavascriptResult res = result;
             AlertDialog.Builder dlg = new AlertDialog.Builder(this.cordova.getActivity());
             dlg.setMessage(message);
             final EditText input = new EditText(this.cordova.getActivity());
@@ -278,7 +286,7 @@ public class CordovaChromeClient extends XWalkDefaultWebChromeClient {
                     new DialogInterface.OnClickListener() {
                         public void onClick(DialogInterface dialog, int which) {
                             String usertext = input.getText().toString();
-                            res.confirm(usertext);
+                            res.confirmWithResult(usertext);
                         }
                     });
             dlg.setNegativeButton(android.R.string.cancel,
@@ -293,63 +301,19 @@ public class CordovaChromeClient extends XWalkDefaultWebChromeClient {
         return true;
     }
 
-    /**
-     * Handle database quota exceeded notification.
-     */
-    @Override
-    public void onExceededDatabaseQuota(String url, String databaseIdentifier, long currentQuota, long estimatedSize,
-            long totalUsedQuota, WebStorage.QuotaUpdater quotaUpdater)
-    {
-        LOG.d(TAG, "onExceededDatabaseQuota estimatedSize: %d  currentQuota: %d  totalUsedQuota: %d", estimatedSize, currentQuota, totalUsedQuota);
-        quotaUpdater.updateQuota(MAX_QUOTA);
+    // TODO(yongsheng): remove the dependency of Crosswalk internal class?
+    class CordovaWebChromeClient extends XWalkWebChromeClient {
+    // Don't add extra indents for keeping them with upstream to avoid
+    // merge conflicts.
+    private View mVideoProgressView;
+
+    private CordovaWebView appView;
+
+    CordovaWebChromeClient(Context context, CordovaWebView view) {
+        super(context, view);
+        appView = view;
     }
 
-    // console.log in api level 7: http://developer.android.com/guide/developing/debug-tasks.html
-    // Expect this to not compile in a future Android release!
-    @SuppressWarnings("deprecation")
-    @Override
-    public void onConsoleMessage(String message, int lineNumber, String sourceID)
-    {
-        //This is only for Android 2.1
-        if(android.os.Build.VERSION.SDK_INT == android.os.Build.VERSION_CODES.ECLAIR_MR1)
-        {
-            LOG.d(TAG, "%s: Line %d : %s", sourceID, lineNumber, message);
-            super.onConsoleMessage(message, lineNumber, sourceID);
-        }
-    }
-
-    @TargetApi(8)
-    @Override
-    public boolean onConsoleMessage(ConsoleMessage consoleMessage)
-    {
-        if (consoleMessage.message() != null)
-            LOG.d(TAG, "%s: Line %d : %s" , consoleMessage.sourceId() , consoleMessage.lineNumber(), consoleMessage.message());
-         return super.onConsoleMessage(consoleMessage);
-    }
-
-    @Override
-    /**
-     * Instructs the client to show a prompt to ask the user to set the Geolocation permission state for the specified origin.
-     *
-     * @param origin
-     * @param callback
-     */
-    public void onGeolocationPermissionsShowPrompt(String origin, XWalkGeolocationPermissions.Callback callback) {
-        super.onGeolocationPermissionsShowPrompt(origin, callback);
-        callback.invoke(origin, true, false);
-    }
-    
-    // API level 7 is required for this, see if we could lower this using something else
-    @Override
-    public void onShowCustomView(View view, XWalkWebChromeClient.CustomViewCallback callback) {
-        this.appView.showCustomView(view, callback);
-    }
-
-	@Override
-	public void onHideCustomView() {
-    	this.appView.hideCustomView();
-	}
-    
     @Override
     /**
      * Ask the host application for a custom progress view to show while
@@ -378,8 +342,11 @@ public class CordovaChromeClient extends XWalkDefaultWebChromeClient {
 	    }
     return mVideoProgressView; 
     }
+    }
     
-    public void openFileChooser(ValueCallback<Uri> uploadMsg) {
+    @Override
+    public void openFileChooser(XWalkView view, ValueCallback<Uri> uploadMsg, String acceptType,
+            String capture) {
         this.openFileChooser(uploadMsg, "*/*");
     }
 

--- a/framework/src/org/apache/cordova/CordovaWebView.java
+++ b/framework/src/org/apache/cordova/CordovaWebView.java
@@ -60,11 +60,12 @@ import android.view.inputmethod.InputMethodManager;
 //import android.webkit.WebSettings.LayoutAlgorithm;
 import android.widget.FrameLayout;
 
-import org.xwalk.core.WebBackForwardList;
-import org.xwalk.core.WebHistoryItem;
+import org.xwalk.core.XWalkNavigationHistory;
+import org.xwalk.core.XWalkNavigationItem;
+import org.xwalk.core.XWalkPreferences;
+import org.xwalk.core.XWalkSettings;
 import org.xwalk.core.XWalkView;
 import org.xwalk.core.XWalkWebChromeClient;
-import org.xwalk.core.XWalkSettings;
 
 /*
  * This class is our web view.
@@ -245,12 +246,14 @@ public class CordovaWebView extends XWalkView {
     @SuppressWarnings("deprecation")
     @SuppressLint("NewApi")
     private void setup() {
-        this.setInitialScale(0);
+        // this.setInitialScale(0);
         this.setVerticalScrollBarEnabled(false);
         if (shouldRequestFocusOnInit()) {
-			this.requestFocusFromTouch();
-		}
-		// Enable JavaScript
+            this.requestFocusFromTouch();
+        }
+
+        // TODO(yongsheng): remove settings?
+        // Enable JavaScript
         XWalkSettings settings = this.getSettings();
         settings.setJavaScriptEnabled(true);
         settings.setJavaScriptCanOpenWindowsAutomatically(true);
@@ -282,9 +285,8 @@ public class CordovaWebView extends XWalkView {
             
             appInfo = pm.getApplicationInfo(packageName, PackageManager.GET_META_DATA);
             
-            if((appInfo.flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0)
-            {
-                this.enableRemoteDebugging();
+            if((appInfo.flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0) {
+                XWalkPreferences.setValue(XWalkPreferences.REMOTE_DEBUGGING, true);
             }
         } catch (IllegalArgumentException e) {
             Log.d(TAG, "You have one job! To turn on Remote Web Debugging! YOU HAVE FAILED! ");
@@ -351,7 +353,7 @@ public class CordovaWebView extends XWalkView {
      */
     public void setWebViewClient(CordovaWebViewClient client) {
         this.viewClient = client;
-        super.setXWalkClient(client);
+        super.setResourceClient(client);
     }
 
     /**
@@ -361,7 +363,7 @@ public class CordovaWebView extends XWalkView {
      */
     public void setWebChromeClient(CordovaChromeClient client) {
         this.chromeClient = client;
-        super.setXWalkWebChromeClient(client);
+        super.setUIClient(client);
     }
     
     public CordovaChromeClient getWebChromeClient() {
@@ -374,7 +376,7 @@ public class CordovaWebView extends XWalkView {
      * @param url
      */
     @Override
-    public void loadUrl(String url) {
+    public void load(String url, String content) {
         if (url.equals("about:blank") || url.startsWith("javascript:")) {
             this.loadUrlNow(url);
         }
@@ -391,6 +393,10 @@ public class CordovaWebView extends XWalkView {
                 this.loadUrlIntoView(initUrl);
             }
         }
+    }
+
+    public void loadUrl(String url) {
+        load(url, null);
     }
 
     /**
@@ -436,7 +442,7 @@ public class CordovaWebView extends XWalkView {
                 me.stopLoading();
                 LOG.e(TAG, "CordovaWebView: TIMEOUT ERROR!");
                 if (viewClient != null) {
-                    viewClient.onReceivedError(me, -6, "The connection to the server was unsuccessful.", url);
+                    viewClient.onReceivedLoadError(me, -6, "The connection to the server was unsuccessful.", url);
                 }
             }
         };
@@ -479,7 +485,7 @@ public class CordovaWebView extends XWalkView {
             LOG.d(TAG, ">>> loadUrlNow()");
         }
         if (url.startsWith("file://") || url.startsWith("javascript:") || Config.isUrlWhiteListed(url)) {
-            super.loadUrl(url);
+            super.load(url, null);
         }
     }
 
@@ -494,7 +500,7 @@ public class CordovaWebView extends XWalkView {
 
         // If not first page of app, then load immediately
         // Add support for browser history if we use it.
-        if ((url.startsWith("javascript:")) || this.canGoBack()) {
+        if ((url.startsWith("javascript:")) || this.getNavigationHistory().canGoBack()) {
         }
 
         // If first page, then show splashscreen
@@ -562,10 +568,10 @@ public class CordovaWebView extends XWalkView {
 
         // Check webview first to see if there is a history
         // This is needed to support curPage#diffLink, since they are added to appView's history, but not our history url array (JQMobile behavior)
-        if (super.canGoBack()) {
+        if (super.getNavigationHistory().canGoBack()) {
             printBackForwardList();
-            super.goBack();
             
+            super.getNavigationHistory().navigate(XWalkNavigationHistory.Direction.BACKWARD, 1);
             return true;
         }
         return false;
@@ -587,7 +593,7 @@ public class CordovaWebView extends XWalkView {
 
         // If clearing history
         if (clearHistory) {
-            this.clearHistory();
+            this.getNavigationHistory().clear();
         }
 
         // If loading into our webview
@@ -714,8 +720,8 @@ public class CordovaWebView extends XWalkView {
         // If back key
         if (keyCode == KeyEvent.KEYCODE_BACK) {
             // A custom view is currently displayed  (e.g. playing a video)
-            if (this.isFullscreen()) {
-                this.exitFullscreen();
+            if (this.hasEnteredFullscreen()) {
+                this.leaveFullscreen();
                 return true;
             } else if (mCustomView != null) {
                 this.hideCustomView();
@@ -814,7 +820,7 @@ public class CordovaWebView extends XWalkView {
             // Pause JavaScript timers (including setInterval)
             this.pauseTimers();
         }
-        this.onPause();
+        this.onHide();
         paused = true;
    
     }
@@ -831,7 +837,7 @@ public class CordovaWebView extends XWalkView {
 
         // Resume JavaScript timers (including setInterval)
         this.resumeTimers();
-        this.onResume();
+        this.onShow();
         paused = false;
     }
     
@@ -889,11 +895,11 @@ public class CordovaWebView extends XWalkView {
     }
     
     public void printBackForwardList() {
-        WebBackForwardList currentList = this.copyBackForwardList();
-        int currentSize = currentList.getSize();
+        XWalkNavigationHistory currentList = this.getNavigationHistory();
+        int currentSize = currentList.size();
         for(int i = 0; i < currentSize; ++i)
         {
-            WebHistoryItem item = currentList.getItemAtIndex(i);
+            XWalkNavigationItem item = currentList.getItemAt(i);
             String url = item.getUrl();
             LOG.d(TAG, "The URL at index: " + Integer.toString(i) + " is " + url );
         }
@@ -903,8 +909,8 @@ public class CordovaWebView extends XWalkView {
     //Can Go Back is BROKEN!
     public boolean startOfHistory()
     {
-        WebBackForwardList currentList = this.copyBackForwardList();
-        WebHistoryItem item = currentList.getItemAtIndex(0);
+        XWalkNavigationHistory currentList = this.getNavigationHistory();
+        XWalkNavigationItem item = currentList.getItemAt(0);
         if( item!=null){	// Null-fence in case they haven't called loadUrl yet (CB-2458)
 	        String url = item.getUrl();
 	        String currentUrl = this.getUrl();
@@ -968,13 +974,14 @@ public class CordovaWebView extends XWalkView {
         return mCustomView != null;
     }
     
-    public WebBackForwardList restoreState(Bundle savedInstanceState)
+    @Override
+    public boolean restoreState(Bundle savedInstanceState)
     {
-        WebBackForwardList myList = super.restoreState(savedInstanceState);
+        boolean result = super.restoreState(savedInstanceState);
         Log.d(TAG, "WebView restoration crew now restoring!");
         //Initialize the plugin manager once more
         this.pluginManager.init();
-        return myList;
+        return result;
     }
 
     public void storeResult(int requestCode, int resultCode, Intent intent) {

--- a/framework/src/org/apache/cordova/IceCreamCordovaWebViewClient.java
+++ b/framework/src/org/apache/cordova/IceCreamCordovaWebViewClient.java
@@ -46,7 +46,7 @@ public class IceCreamCordovaWebViewClient extends CordovaWebViewClient {
     }
 
     @Override
-    public WebResourceResponse shouldInterceptRequest(XWalkView view, String url) {
+    public WebResourceResponse shouldInterceptLoadRequest(XWalkView view, String url) {
         try {
             // Check the against the white-list.
             if ((url.startsWith("http:") || url.startsWith("https:")) && !Config.isUrlWhiteListed(url)) {


### PR DESCRIPTION
Crosswalk defines the new embedding API which is public to external users.
Migrate Cordova container to use the new API. Due to some legacy issues,
there are still some remaining dependencies in Cordova on Crosswalk internal
classes, including XWalkSettings, XWalkClient, XWalkWebChromeClient and
XWalkHttpAuthHandler.
Next is to figure out how to remove above dependencies.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1375
