### PR TITLE
Don't use two classes XWalkUIClientImpl and XWalkResourceClientImpl.

### DIFF
--- a/framework/src/org/apache/cordova/CordovaChromeClient.java
+++ b/framework/src/org/apache/cordova/CordovaChromeClient.java
@@ -41,7 +41,7 @@ import android.widget.RelativeLayout;
 
 import org.xwalk.core.XWalkJavascriptResult;
 import org.xwalk.core.XWalkWebChromeClient;
-import org.xwalk.core.XWalkUIClientImpl;
+import org.xwalk.core.XWalkUIClient;
 import org.xwalk.core.XWalkView;
 /**
  * This class is the WebChromeClient that implements callbacks for our web view.
@@ -54,7 +54,7 @@ import org.xwalk.core.XWalkView;
  * @see CordovaWebViewClient
  * @see CordovaWebView
  */
-public class CordovaChromeClient extends XWalkUIClientImpl {
+public class CordovaChromeClient extends XWalkUIClient {
 
     public static final int FILECHOOSER_RESULTCODE = 5173;
     protected CordovaInterface cordova;
@@ -69,7 +69,7 @@ public class CordovaChromeClient extends XWalkUIClientImpl {
      * @param cordova
      */
     public CordovaChromeClient(CordovaInterface cordova) {
-        super(cordova.getActivity(), null);
+        super(null);
         this.cordova = cordova;
     }
 
@@ -80,7 +80,7 @@ public class CordovaChromeClient extends XWalkUIClientImpl {
      * @param app
      */
     public CordovaChromeClient(CordovaInterface ctx, CordovaWebView app) {
-        super(ctx.getActivity(), app);
+        super(app);
         this.cordova = ctx;
         this.appView = app;
         this.appView.setXWalkWebChromeClient(new CordovaWebChromeClient(ctx.getActivity(), app));
@@ -310,7 +310,7 @@ public class CordovaChromeClient extends XWalkUIClientImpl {
     private CordovaWebView appView;
 
     CordovaWebChromeClient(Context context, CordovaWebView view) {
-        super(context, view);
+        super(view);
         appView = view;
     }
 

--- a/framework/src/org/apache/cordova/CordovaWebViewClient.java
+++ b/framework/src/org/apache/cordova/CordovaWebViewClient.java
@@ -45,7 +45,7 @@ import android.webkit.WebResourceResponse;
 //import android.webkit.WebView;
 //import android.webkit.WebViewClient;
 import org.chromium.net.NetError;
-import org.xwalk.core.XWalkResourceClientImpl;
+import org.xwalk.core.XWalkResourceClient;
 import org.xwalk.core.XWalkView;
 import org.xwalk.core.XWalkClient;
 import org.xwalk.core.XWalkHttpAuthHandler;
@@ -62,7 +62,7 @@ import org.xwalk.core.XWalkHttpAuthHandler;
  * @see CordovaChromeClient
  * @see CordovaWebView
  */
-public class CordovaWebViewClient extends XWalkResourceClientImpl {
+public class CordovaWebViewClient extends XWalkResourceClient {
 
 	private static final String TAG = "CordovaWebViewClient";
 	private static final String CORDOVA_EXEC_URL_PREFIX = "http://cdv_exec/";
@@ -111,7 +111,7 @@ public class CordovaWebViewClient extends XWalkResourceClientImpl {
      * @param cordova
      */
     public CordovaWebViewClient(CordovaInterface cordova) {
-        super(cordova.getActivity(), null);
+        super(null);
         this.cordova = cordova;
     }
 
@@ -122,7 +122,7 @@ public class CordovaWebViewClient extends XWalkResourceClientImpl {
      * @param view
      */
     public CordovaWebViewClient(CordovaInterface cordova, CordovaWebView view) {
-        super(cordova.getActivity(), view);
+        super(view);
         this.cordova = cordova;
         this.appView = view;
         this.appView.setXWalkClient(new CordovaInternalViewClient(view, cordova));
@@ -298,7 +298,7 @@ public class CordovaWebViewClient extends XWalkResourceClientImpl {
     private boolean doClearHistory = false;
 
     CordovaInternalViewClient(CordovaWebView view, CordovaInterface ci) {
-        super(view.getActivity(), view);
+        super(view);
         cordova = ci;
         appView = view;
     }


### PR DESCRIPTION
Both 2 classes are removed out of Crosswalk core library. Use
the public classes XWalkUIClient and XWalkResourceClient.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1481
