### PR TITLE
Add two network related permissions to AndroidManifest.xml

### DIFF
--- a/bin/templates/project/AndroidManifest.xml
+++ b/bin/templates/project/AndroidManifest.xml
@@ -28,6 +28,8 @@
         android:anyDensity="true"
         />
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application android:icon="@drawable/icon" android:label="@string/app_name"

--- a/test/AndroidManifest.xml
+++ b/test/AndroidManifest.xml
@@ -32,6 +32,8 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_LOCATION_EXTRA_COMMANDS" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.RECEIVE_SMS" />


### PR DESCRIPTION
XWalk Core library will auto detect network status, and below two permissions are needed:
  android.permission.ACCESS_NETWORK_STATE
  android.permission.ACCESS_WIFI_STATE
Add these two permissions to AndroidManifest.xml

BUG=XWALK-1480
