### PR TITLE
Fix XWALK-1615 Cordova API test fails due to no JavaScript API exposed

### DIFF
--- a/framework/src/org/apache/cordova/ExposedJsApi.java
+++ b/framework/src/org/apache/cordova/ExposedJsApi.java
@@ -18,8 +18,7 @@
 */
 package org.apache.cordova;
 
-//import android.webkit.JavascriptInterface;
-import org.chromium.content.browser.JavascriptInterface;
+import org.xwalk.core.JavascriptInterface;
 import org.apache.cordova.PluginManager;
 import org.json.JSONException;
 


### PR DESCRIPTION
Update the ExposedJsApi according to annotation of
XWalkView.addJavascriptInterface().
See https://crosswalk-project.org/jira/browse/XWALK-1596 for details.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1615
