### PR TITLE
Fix that cordova activity uses XWalk API with null pointer check

### DIFF
--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -428,7 +428,9 @@ public class CordovaActivity extends Activity implements CordovaInterface {
 
         // If loadingDialog property, then show the App loading dialog for first page of app
         String loading = null;
-        if ((this.appView == null) || !this.appView.getNavigationHistory().canGoBack()) {
+        if ((this.appView == null) ||
+                this.appView.getNavigationHistory() == null ||
+                !this.appView.getNavigationHistory().canGoBack()) {
             loading = this.getStringProperty("LoadingDialog", null);
         }
         else {
@@ -478,7 +480,9 @@ public class CordovaActivity extends Activity implements CordovaInterface {
      * Clear web history in this web view.
      */
     public void clearHistory() {
-        this.appView.getNavigationHistory().clear();
+        if (this.appView.getNavigationHistory() != null) {
+            this.appView.getNavigationHistory().clear();
+        }
     }
 
     /**

--- a/framework/src/org/apache/cordova/CordovaWebView.java
+++ b/framework/src/org/apache/cordova/CordovaWebView.java
@@ -255,6 +255,7 @@ public class CordovaWebView extends XWalkView {
         // TODO(yongsheng): remove settings?
         // Enable JavaScript
         XWalkSettings settings = this.getSettings();
+        if (settings == null) return;
         settings.setJavaScriptEnabled(true);
         settings.setJavaScriptCanOpenWindowsAutomatically(true);
         // nhu: N/A
@@ -432,7 +433,9 @@ public class CordovaWebView extends XWalkView {
 
         if (recreatePlugins) {
             this.url = url;
-            this.pluginManager.init();
+            if (this.pluginManager != null) {
+                this.pluginManager.init();
+            }
         }
 
         // Create a timeout timer for loadUrl
@@ -979,7 +982,9 @@ public class CordovaWebView extends XWalkView {
         boolean result = super.restoreState(savedInstanceState);
         Log.d(TAG, "WebView restoration crew now restoring!");
         //Initialize the plugin manager once more
-        this.pluginManager.init();
+        if (this.pluginManager != null) {
+            this.pluginManager.init();
+        }
         return result;
     }
 


### PR DESCRIPTION
In some cases, XWalkView will fail to initialize, e.g. CPU
architecture mismatch detected. Need to check null pointer
to keep Cordova App from crash in such case.

BUG=https://crosswalk-project.org/jira/browse/XWALK-1616
