### PR TITLE
Change layout of splash dialog when orientation changed

### DIFF
--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -39,6 +39,8 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.graphics.Color;
+import android.graphics.Point;
+import android.hardware.SensorManager;
 import android.media.AudioManager;
 import android.net.Uri;
 import android.os.Bundle;
@@ -48,6 +50,7 @@ import android.view.Display;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.OrientationEventListener;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
@@ -886,7 +889,7 @@ public class CordovaActivity extends Activity implements CordovaInterface {
             this.appView.onActivityResult(requestCode, resultCode, intent);
         Log.d(TAG, "Request code = " + requestCode);
         if (appView != null && requestCode == CordovaChromeClient.FILECHOOSER_RESULTCODE) {
-        	ValueCallback<Uri> mUploadMessage = this.appView.getWebChromeClient().getValueCallback();
+                ValueCallback<Uri> mUploadMessage = this.appView.getWebChromeClient().getValueCallback();
             Log.d(TAG, "did we get here?");
             if (null == mUploadMessage)
                 return;
@@ -1048,6 +1051,9 @@ public class CordovaActivity extends Activity implements CordovaInterface {
     }
 
     protected Dialog splashDialog;
+    protected OrientationEventListener splashOrientationListener;
+    protected int mCurrentOrientation;
+    protected LinearLayout splashLayout;
 
     /**
      * Removes the Dialog that displays the splash screen
@@ -1056,7 +1062,40 @@ public class CordovaActivity extends Activity implements CordovaInterface {
         if (splashDialog != null && splashDialog.isShowing()) {
             splashDialog.dismiss();
             splashDialog = null;
+            splashOrientationListener.disable();
+            splashOrientationListener = null;
         }
+    }
+
+    protected int getScreenOrientation() {
+        // getResources().getConfiguration().orientation returns wrong value in some devices.
+        // Below is another way to calculate screen orientation.
+        Display display = getWindowManager().getDefaultDisplay();
+        Point size = new Point();
+        display.getSize(size);
+        int orientation;
+        if (size.x < size.y) {
+            orientation = Configuration.ORIENTATION_PORTRAIT;
+        } else {
+            orientation = Configuration.ORIENTATION_LANDSCAPE;
+        }
+        return orientation;
+    }
+
+    protected LinearLayout getSplashLayout() {
+        // Get reference to display
+        Display display = getWindowManager().getDefaultDisplay();
+
+        LinearLayout root = new LinearLayout(getActivity());
+        root.setMinimumHeight(display.getHeight());
+        root.setMinimumWidth(display.getWidth());
+        root.setOrientation(LinearLayout.VERTICAL);
+        root.setBackgroundColor(getIntegerProperty("backgroundColor", Color.BLACK));
+        root.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT, 0.0F));
+        root.setBackgroundResource(splashscreen);
+
+        return root;
     }
 
     /**
@@ -1068,19 +1107,8 @@ public class CordovaActivity extends Activity implements CordovaInterface {
 
         Runnable runnable = new Runnable() {
             public void run() {
-                // Get reference to display
-                Display display = getWindowManager().getDefaultDisplay();
-
                 // Create the layout for the dialog
-                LinearLayout root = new LinearLayout(that.getActivity());
-                root.setMinimumHeight(display.getHeight());
-                root.setMinimumWidth(display.getWidth());
-                root.setOrientation(LinearLayout.VERTICAL);
-                root.setBackgroundColor(that.getIntegerProperty("backgroundColor", Color.BLACK));
-                root.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-                        ViewGroup.LayoutParams.MATCH_PARENT, 0.0F));
-                root.setBackgroundResource(that.splashscreen);
-                
+                splashLayout = getSplashLayout();
                 // Create and show the dialog
                 splashDialog = new Dialog(that, android.R.style.Theme_Translucent_NoTitleBar);
                 // check to see if the splash screen should be full screen
@@ -1089,9 +1117,27 @@ public class CordovaActivity extends Activity implements CordovaInterface {
                     splashDialog.getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
                             WindowManager.LayoutParams.FLAG_FULLSCREEN);
                 }
-                splashDialog.setContentView(root);
+                splashDialog.setContentView(splashLayout);
                 splashDialog.setCancelable(false);
                 splashDialog.show();
+
+                mCurrentOrientation = getScreenOrientation();
+                splashOrientationListener = new OrientationEventListener(that,
+                        SensorManager.SENSOR_DELAY_NORMAL) {
+                    public void onOrientationChanged(int ori) {
+                        if (splashDialog == null || !splashDialog.isShowing()) {
+                            return;
+                        }
+                        // Reset contentView of splashDialog when orientation changed.
+                        int orientation = getScreenOrientation();
+                        if (orientation != mCurrentOrientation) {
+                            splashLayout = getSplashLayout();
+                            splashDialog.setContentView(splashLayout);
+                            mCurrentOrientation = orientation;
+                        }
+                    }
+                };
+                splashOrientationListener.enable();
 
                 // Set Runnable to remove splash screen just in case
                 final Handler handler = new Handler();
@@ -1113,7 +1159,7 @@ public class CordovaActivity extends Activity implements CordovaInterface {
             return appView.onKeyUp(keyCode, event);
         } else {
             return super.onKeyUp(keyCode, event);
-    	}
+        }
     }
     
     /*


### PR DESCRIPTION
Developer will provide two splash screen images for landscape and portrait mode.
Currently it will auto stretch the splash screen layout when orientation changed.
This fix can change the layout as developer needed for different orientations.

BUG=XWALK-1810
