### PR TITLE
Disable multiple windows to align navigation behavior with upstream.

### DIFF
--- a/framework/src/org/apache/cordova/CordovaWebView.java
+++ b/framework/src/org/apache/cordova/CordovaWebView.java
@@ -942,5 +942,7 @@ public class CordovaWebView extends XWalkView {
         XWalkPreferences.setValue("javascript-can-open-window", true);
         // XWalkPreferencesInternal.ALLOW_UNIVERSAL_ACCESS_FROM_FILE
         XWalkPreferences.setValue("allow-universal-access-from-file", true);
+        // XWalkPreferencesInternal.SUPPORT_MULTIPLE_WINDOWS
+        XWalkPreferences.setValue("support-multiple-windows", false);
     }
 }


### PR DESCRIPTION
As Crosswalk enable multiple windows to implement opening url with system
default browser, the navigation by clicking <a target="_blank"> in Cordova
was blocked, so disable multiple windows with XWalkPreferences.

To open urls in system default browser, the InAppBrowser plugin should be
used.
