### PR TITLE
Fix the layout issue happens when app was switched back from background.

### DIFF
--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -765,7 +765,9 @@ public class CordovaActivity extends Activity implements CordovaInterface {
         }
 
         // When back from background, we need to reset fullscreen mode.
-        toggleFullscreen(getWindow());
+        if(getBooleanProperty("FullScreen", false)) {
+            toggleFullscreen(getWindow());
+        }
 
         this.appView.handleResume(this.keepRunning, this.activityResultKeepRunning);
 


### PR DESCRIPTION
In the activity onResume() method, the view enters fullscreen mode
without checking the Fullscreen property. An if condition was added
to fix the issue.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2187
