### PR TITLE
Fixed CordovaActivity.java toogleFullscreen method

### DIFF
--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -278,11 +278,7 @@ public class CordovaActivity extends Activity implements CordovaInterface {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             final int uiOptions =
                     View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                    | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                    | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                    | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                    | View.SYSTEM_UI_FLAG_FULLSCREEN
-                    | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY;
+                    | View.SYSTEM_UI_FLAG_FULLSCREEN;
 
             window.getDecorView().setSystemUiVisibility(uiOptions);
         } else {


### PR DESCRIPTION
On KitKat the cordova app would always go to full screen after resume.
Commenting out the flags will have the fullscreen behaviour you set in the /res/config.xml on the fullscreen flag.
