### PR TITLE
Fix white screen issue when application paused

### DIFF
--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -704,8 +704,6 @@ public class CordovaActivity extends Activity implements CordovaInterface {
      */
     protected void onPause() {
         super.onPause();
-        if (this.appView != null)
-            this.appView.onHide();
 
         LOG.d(TAG, "Paused the application!");
 
@@ -743,8 +741,6 @@ public class CordovaActivity extends Activity implements CordovaInterface {
      */
     protected void onResume() {
         super.onResume();
-        if (this.appView != null)
-            this.appView.onShow();
         //Reload the configuration
         Config.init(this);
 

--- a/framework/src/org/apache/cordova/CordovaWebView.java
+++ b/framework/src/org/apache/cordova/CordovaWebView.java
@@ -823,7 +823,6 @@ public class CordovaWebView extends XWalkView {
             // Pause JavaScript timers (including setInterval)
             this.pauseTimers();
         }
-        this.onHide();
         paused = true;
    
     }
@@ -840,7 +839,6 @@ public class CordovaWebView extends XWalkView {
 
         // Resume JavaScript timers (including setInterval)
         this.resumeTimers();
-        this.onShow();
         paused = false;
     }
     


### PR DESCRIPTION
onShow() and onHide() will be called by XWalkView internally, depends on activity lifecycle change.
Avoid calling these two methods directly, otherwise there will be a white screen displayed.

BUG=XWALK-1970

(cherry picked from commit d32a634699cb480d8d5b0869be3e7c5092936e56)
