### PR TITLE
Fix issue of failing to launch camera when tapping input tag.

### DIFF
--- a/framework/src/org/apache/cordova/CordovaChromeClient.java
+++ b/framework/src/org/apache/cordova/CordovaChromeClient.java
@@ -344,21 +344,7 @@ public class CordovaChromeClient extends XWalkUIClient {
     @Override
     public void openFileChooser(XWalkView view, ValueCallback<Uri> uploadMsg, String acceptType,
             String capture) {
-        this.openFileChooser(uploadMsg, "*/*");
-    }
-
-    public void openFileChooser( ValueCallback<Uri> uploadMsg, String acceptType ) {
-        this.openFileChooser(uploadMsg, acceptType, null);
-    }
-    
-    public void openFileChooser(ValueCallback<Uri> uploadMsg, String acceptType, String capture)
-    {
-        mUploadMessage = uploadMsg;
-        Intent i = new Intent(Intent.ACTION_GET_CONTENT);
-        i.addCategory(Intent.CATEGORY_OPENABLE);
-        i.setType("*/*");
-        this.cordova.getActivity().startActivityForResult(Intent.createChooser(i, "File Browser"),
-                FILECHOOSER_RESULTCODE);
+        uploadMsg.onReceiveValue(null);
     }
     
     public ValueCallback<Uri> getValueCallback() {


### PR DESCRIPTION
The tag is <input type="file" accept="image/*;capture=camera">.
Chromium has already implemented a better file chooser for android,
so bypass that implemented by Cordova.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2148
