### PR TITLE
Don't pause timers when app is backgrounded

### DIFF
--- a/framework/src/org/apache/cordova/CordovaWebView.java
+++ b/framework/src/org/apache/cordova/CordovaWebView.java
@@ -775,7 +775,16 @@ public class CordovaWebView extends XWalkView {
         return super.dispatchKeyEvent(event);
     }
 
-    
+    @Override
+    public void pauseTimers() {
+        // This is called by XWalkViewInternal.onActivityStateChange().
+        // We don't want them paused by default though.
+    }
+
+    public void pauseTimersForReal() {
+        super.pauseTimers();
+    }
+
     public void bindButton(boolean override)
     {
         this.bound = override;
@@ -821,7 +830,7 @@ public class CordovaWebView extends XWalkView {
         // If app doesn't want to run in background
         if (!keepRunning) {
             // Pause JavaScript timers (including setInterval)
-            this.pauseTimers();
+            this.pauseTimersForReal();
         }
         paused = true;
    


### PR DESCRIPTION
Beacuse the JavaScripte timer was paused, the pause event can't send by
setTimeOut function.

Apply a patch from https://github.com/clelland/cordova-crosswalk-engine/
commit/e25e506cf815845480ae6e7a42be6cd0cd94f6bb

BUG=XWALK-2417
