### PR TITLE
Fix issue that app crashs when exit with back key.

### DIFF
--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -784,9 +784,6 @@ public class CordovaActivity extends Activity implements CordovaInterface {
      */
     public void onDestroy() {
         LOG.d(TAG, "CordovaActivity.onDestroy()");
-        super.onDestroy();
-        if (this.appView != null)
-            this.appView.onDestroy();
 
         // hide the splash screen to avoid leaking a window
         this.removeSplashScreen();
@@ -797,6 +794,8 @@ public class CordovaActivity extends Activity implements CordovaInterface {
         else {
             this.activityState = ACTIVITY_EXITING; 
         }
+
+        super.onDestroy();
     }
 
     /**


### PR DESCRIPTION
Adjust the onDestory() invoking in CordovaActivity.java to avoid the
null object reference.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2493
