### PR TITLE
[Android] Disable xwalk view animation

### DIFF
--- a/framework/src/org/apache/cordova/CordovaWebView.java
+++ b/framework/src/org/apache/cordova/CordovaWebView.java
@@ -951,5 +951,7 @@ public class CordovaWebView extends XWalkView {
         XWalkPreferences.setValue("allow-universal-access-from-file", true);
         // XWalkPreferencesInternal.SUPPORT_MULTIPLE_WINDOWS
         XWalkPreferences.setValue("support-multiple-windows", false);
+        // XWalkPreferencesInternal.ANIMATABLE_XWALK_VIEW
+        XWalkPreferences.setValue("animatable-xwalk-view", false);
     }
 }


### PR DESCRIPTION
This animation will cause black screen on x86 device, so disable it.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2588
