### PR TITLE
Backport commit to fix a crash in Android < 4.0.3.

### DIFF
--- a/framework/src/org/apache/cordova/CordovaUriHelper.java
+++ b/framework/src/org/apache/cordova/CordovaUriHelper.java
@@ -21,8 +21,10 @@ package org.apache.cordova;
 
 import org.json.JSONException;
 
+import android.annotation.TargetApi;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.util.Log;
 // import android.webkit.WebView;
 import org.xwalk.core.XWalkView;
@@ -70,6 +72,7 @@ public class CordovaUriHelper {
      * @param url           The url to be loaded.
      * @return              true to override, false for default behavior
      */
+    @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1)
     public boolean shouldOverrideUrlLoading(XWalkView view, String url) {
         // The WebView should support http and https when going on the Internet
         if(url.startsWith("http:") || url.startsWith("https:"))
@@ -101,7 +104,9 @@ public class CordovaUriHelper {
                 intent.setData(Uri.parse(url));
                 intent.addCategory(Intent.CATEGORY_BROWSABLE);
                 intent.setComponent(null);
-                intent.setSelector(null);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1) {
+                    intent.setSelector(null);
+                }
                 this.cordova.getActivity().startActivity(intent);
             } catch (android.content.ActivityNotFoundException e) {
                 LOG.e(TAG, "Error loading url " + url, e);


### PR DESCRIPTION
Commit cherry-picked from the 3.6.x branch, original message:

>  CB-7265 Fix crash when navigating to custom protocol (introduced in 3.5.1)
> 
>  Conflicts:
>   framework/src/org/apache/cordova/CordovaUriHelper.java
> 
>  Github: close #111

This fixes a regression introduced by the 3.5.1 security fixes that cause a crash in Android < 4.0.3 when the webview is redirected to a custom URL scheme.

Apache issue: https://issues.apache.org/jira/browse/CB-7265
