### PR TITLE
Align SSL error behavior with Cordova-Android.

### DIFF
--- a/framework/src/org/apache/cordova/CordovaWebViewClient.java
+++ b/framework/src/org/apache/cordova/CordovaWebViewClient.java
@@ -161,6 +161,34 @@ public class CordovaWebViewClient extends XWalkResourceClient {
     public boolean shouldOverrideUrlLoading(XWalkView view, String url) {
         return helper.shouldOverrideUrlLoading(view, url);
     }
+
+    /**
+    * Notify the host application that an SSL error occurred while loading a
+    * resource. The host application must call either callback.onReceiveValue(true)
+    * or callback.onReceiveValue(false). Note that the decision may be
+    * retained for use in response to future SSL errors. The default behavior
+    * is to pop up a dialog.
+    */
+    public void onReceivedSslError(XWalkView view, ValueCallback<Boolean> callback, SslError error) {
+        final String packageName = this.cordova.getActivity().getPackageName();
+        final PackageManager pm = this.cordova.getActivity().getPackageManager();
+
+        ApplicationInfo appInfo;
+        try {
+            appInfo = pm.getApplicationInfo(packageName, PackageManager.GET_META_DATA);
+            if ((appInfo.flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0) {
+                // debug = true
+                callback.onReceiveValue(true);
+                return;
+            } else {
+                // debug = false
+                callback.onReceiveValue(false);
+            }
+        } catch (NameNotFoundException e) {
+            // When it doubt, lock it out!
+            callback.onReceiveValue(false);
+        }
+    }
     
     /**
      * Sets the authentication token.


### PR DESCRIPTION
Cordova-Android ignores all SSL errors for debug builds, and fails on
SSL errors in release builds.

Crosswalk-Cordova-Android shows an alert dialog that lets the user
ignore the SSL error or cancel the request. This behavior is surprising
to Web platform developers, as typical browser behavior matches that of
Cordova-Android for release builds.

This change implements the Cordova-Android behavior, using the recently
introduced XWalkResourceClient::onReceivedSslError() hook.

BUG=XWALK-2911
