### PR TITLE
Request focus on XWalkView to listener volume button

### DIFF
--- a/framework/src/org/apache/cordova/CordovaWebView.java
+++ b/framework/src/org/apache/cordova/CordovaWebView.java
@@ -185,6 +185,7 @@ public class CordovaWebView extends XWalkView {
         this.setVerticalScrollBarEnabled(false);
         // TODO: The Activity is the one that should call requestFocus().
         if (shouldRequestFocusOnInit()) {
+            this.setFocusableInTouchMode(true);
             this.requestFocusFromTouch();
         }
 
@@ -688,6 +689,12 @@ public class CordovaWebView extends XWalkView {
         else if (keyCode == KeyEvent.KEYCODE_SEARCH) {
             this.loadUrl("javascript:cordova.fireDocumentEvent('searchbutton');");
             return true;
+        }
+        // Request focus on XWalkView
+        else if((keyCode == KeyEvent.KEYCODE_VOLUME_DOWN || keyCode == KeyEvent.KEYCODE_VOLUME_UP) &&
+                !isFocused()) {
+            requestFocus();
+            return super.dispatchKeyEvent(event);
         }
 
         //Does webkit change this behavior?


### PR DESCRIPTION
The XWalkView has no focus after loading web page, it can't receive the onKeyListener and onKeyDown event, so the volume-button plugin and the Cordova volume event can't work.

BUG=XWALK-2424 XWALK-2835
