### PR TITLE
Reset CordovaBridge correctly on navigation.

### DIFF
--- a/framework/src/org/apache/cordova/CordovaChromeClient.java
+++ b/framework/src/org/apache/cordova/CordovaChromeClient.java
@@ -252,7 +252,7 @@ public class CordovaChromeClient extends XWalkUIClient {
         isCurrentlyLoading = true;
 
         // Flush stale messages.
-        this.appView.bridge.getMessageQueue().reset();
+        this.appView.bridge.reset(url);
 
         // Broadcast message that page has loaded
         this.appView.postMessage("onPageStarted", url);


### PR DESCRIPTION
If the bridge is reset incorrectly, its loadedUrl remains null, which
causes a NullPointerException when a non-file:// page tries to connect
to the bridge via prompt().

Relevant upstream code:
https://github.com/apache/cordova-android/blob/master/framework/src/org/apache/cordova/CordovaWebViewClient.java#L144

BUG=XWALK-2907

(cherry picked from commit 88a9e71d3262579f859344ff8172ffb882608b70)
