### PR TITLE
CB-7674 move preference activation back into onCreate()

### DIFF
--- a/bin/templates/project/Activity.java
+++ b/bin/templates/project/Activity.java
@@ -28,6 +28,7 @@ public class __ACTIVITY__ extends CordovaActivity
     public void onCreate(Bundle savedInstanceState)
     {
         super.onCreate(savedInstanceState);
+        super.init();
         // Set by <content src="index.html" /> in config.xml
         loadUrl(launchUrl);
     }

--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -54,6 +54,7 @@ import android.view.MenuItem;
 import android.view.OrientationEventListener;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewParent;
 import android.view.Window;
 import android.view.WindowManager;
 import android.webkit.ValueCallback;
@@ -77,6 +78,7 @@ import android.widget.LinearLayout;
  *       &#64;Override
  *       public void onCreate(Bundle savedInstanceState) {
  *         super.onCreate(savedInstanceState);
+ *         super.init();
  *         // Load your application
  *         loadUrl(launchUrl);
  *       }
@@ -205,14 +207,32 @@ public class CordovaActivity extends Activity implements CordovaInterface {
     public void onCreate(Bundle savedInstanceState) {
         LOG.i(TAG, "Apache Cordova native platform version " + CordovaWebView.CORDOVA_VERSION + " is starting");
         LOG.d(TAG, "CordovaActivity.onCreate()");
+
+        // need to activate preferences before super.onCreate to avoid "requestFeature() must be called before adding content" exception
+        loadConfig();
+        if(!preferences.getBoolean("ShowTitle", false))
+        {
+            getWindow().requestFeature(Window.FEATURE_NO_TITLE);
+        }
+        
+        if(preferences.getBoolean("SetFullscreen", false))
+        {
+            Log.d(TAG, "The SetFullscreen configuration is deprecated in favor of Fullscreen, and will be removed in a future version.");
+            getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
+                    WindowManager.LayoutParams.FLAG_FULLSCREEN);
+        } else if (preferences.getBoolean("Fullscreen", false)) {
+            toggleFullscreen(getWindow());
+        } else {
+            getWindow().setFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN,
+                    WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+        }
+
         super.onCreate(savedInstanceState);
 
         if(savedInstanceState != null)
         {
             initCallbackClass = savedInstanceState.getString("callbackClass");
         }
-        
-        loadConfig();
     }
 
     @SuppressWarnings("deprecation")
@@ -232,7 +252,9 @@ public class CordovaActivity extends Activity implements CordovaInterface {
     @SuppressWarnings("deprecation")
     protected void createViews() {
         // This builds the view.  We could probably get away with NOT having a LinearLayout, but I like having a bucket!
-        // This builds the view.  We could probably get away with NOT having a LinearLayout, but I like having a bucket!
+
+        LOG.d(TAG, "CordovaActivity.createViews()");
+
         Display display = getWindowManager().getDefaultDisplay();
         int width = display.getWidth();
         int height = display.getHeight();
@@ -250,6 +272,14 @@ public class CordovaActivity extends Activity implements CordovaInterface {
 
         // Add web view but make it invisible while loading URL
         appView.setVisibility(View.INVISIBLE);
+        
+        // need to remove appView from any existing parent before invoking root.addView(appView)
+        ViewParent parent = appView.getParent();
+        if ((parent != null) && (parent != root)) {
+            LOG.d(TAG, "removing appView from existing parent");
+            ViewGroup parentGroup = (ViewGroup) parent;
+            parentGroup.removeView(appView);
+        }
         root.addView((View) appView);
         setContentView(root);
 
@@ -327,23 +357,6 @@ public class CordovaActivity extends Activity implements CordovaInterface {
     @Deprecated // Call init() instead and override makeWebView() to customize.
     public void init(CordovaWebView webView, CordovaWebViewClient webViewClient, CordovaChromeClient webChromeClient) {
         LOG.d(TAG, "CordovaActivity.init()");
-
-        if(!preferences.getBoolean("ShowTitle", false))
-        {
-            getWindow().requestFeature(Window.FEATURE_NO_TITLE);
-        }
-
-        if(preferences.getBoolean("SetFullscreen", false))
-        {
-            Log.d(TAG, "The SetFullscreen configuration is deprecated in favor of Fullscreen, and will be removed in a future version.");
-            getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
-                    WindowManager.LayoutParams.FLAG_FULLSCREEN);
-        } else if (preferences.getBoolean("Fullscreen", false)) {
-            toggleFullscreen(getWindow());
-        } else {
-            getWindow().setFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN,
-                    WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
-        }
 
         appView = webView != null ? webView : makeWebView();
         if (appView.pluginManager == null) {

--- a/test/res/xml/config.xml
+++ b/test/res/xml/config.xml
@@ -34,6 +34,7 @@
     <preference name="loglevel" value="DEBUG" />
     <preference name="useBrowserHistory" value="true" />
     <preference name="exit-on-suspend" value="false" />
+    <preference name="showTitle" value="true" />
     <feature name="Activity">
         <param name="android-package" value="org.apache.cordova.test.ActivityPlugin" />
     </feature>

--- a/test/src/org/apache/cordova/test/menus.java
+++ b/test/src/org/apache/cordova/test/menus.java
@@ -32,8 +32,7 @@ public class menus extends CordovaActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        // need the title to be shown for the options menu to be visible
-        preferences.set("showTitle", true);
+        // need the title to be shown (config.xml) for the options menu to be visible
         super.init();
         super.registerForContextMenu(super.appView);
         super.loadUrl("file:///android_asset/www/menus/index.html");


### PR DESCRIPTION
The preference creation actually needs to be before
super.onCreate(savedInstance) in order to avoid the exception
"requestFeature() must be called before adding content". Also ran into an
issue in the native tests "Whitelist" and "User WebView/Client/Chrome" where
it would throw an exception that the CordovaWebView appView already had
a parent and needed to be removed from that parent before the invocation
to root.addView(appView). So I conditionally remove the wrong parent.
Also made a change to the native tests so the menus test would work.
I also put super.init() back into the template, though invoking it is optional
as loadUrl will call it automatically if needed.

(cherry picked from commit 90766ae0faa6594a6f4d6b9d61d66af8e3600b8e)

BUG=XWALK-3171

Conflicts:

```
framework/src/org/apache/cordova/CordovaActivity.java
```
