### PR TITLE
Support shared mode for crosswalk library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ framework/libs
 framework/javadoc-public
 framework/javadoc-private
 framework/xwalk_core_library
+framework/xwalk_shared_library
 test/libs
 example
 ./test

--- a/bin/templates/project/Activity.java
+++ b/bin/templates/project/Activity.java
@@ -28,6 +28,10 @@ public class __ACTIVITY__ extends CordovaActivity
     public void onCreate(Bundle savedInstanceState)
     {
         super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    protected void onXWalkReady() {
         super.init();
         // Set by <content src="index.html" /> in config.xml
         loadUrl(launchUrl);

--- a/bin/templates/project/AndroidManifest.xml
+++ b/bin/templates/project/AndroidManifest.xml
@@ -31,8 +31,10 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
-    <application android:icon="@drawable/icon" android:label="@string/app_name"
+    <application android:name="org.apache.cordova.CordovaApplication"
+        android:icon="@drawable/icon" android:label="@string/app_name"
         android:hardwareAccelerated="true">
         <activity android:name="__ACTIVITY__"
                 android:label="@string/activity_name"

--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -28,6 +28,7 @@ import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.LOG;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.xwalk.core.XWalkActivity;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
@@ -78,6 +79,10 @@ import android.widget.LinearLayout;
  *       &#64;Override
  *       public void onCreate(Bundle savedInstanceState) {
  *         super.onCreate(savedInstanceState);
+ *       }
+ *
+ *       &#64;Override
+ *       public void onXWalkReady() {
  *         super.init();
  *         // Load your application
  *         loadUrl(launchUrl);
@@ -92,7 +97,7 @@ import android.widget.LinearLayout;
  * deprecated in favor of the config.xml file.
  *
  */
-public class CordovaActivity extends Activity implements CordovaInterface {
+public abstract class CordovaActivity extends XWalkActivity implements CordovaInterface {
     public static String TAG = "CordovaActivity";
 
     // The webview for our app

--- a/framework/src/org/apache/cordova/CordovaApplication.java
+++ b/framework/src/org/apache/cordova/CordovaApplication.java
@@ -16,22 +16,9 @@
        specific language governing permissions and limitations
        under the License.
 */
-
 package org.apache.cordova;
 
-/**
- * This used to be the class that should be extended by application
- * developers, but everything has been moved to CordovaActivity. So
- * you should extend CordovaActivity instead of DroidGap. This class
- * will be removed at a future time.
- *
- * @see CordovaActivity
- * @deprecated
- */
-@Deprecated
-public class DroidGap extends CordovaActivity {
-    @Override
-    protected void onXWalkReady() {
-    }
+import org.xwalk.core.XWalkApplication;
 
+public class CordovaApplication extends XWalkApplication {
 }

--- a/framework/src/org/apache/cordova/CordovaWebViewClient.java
+++ b/framework/src/org/apache/cordova/CordovaWebViewClient.java
@@ -39,7 +39,6 @@ import android.view.View;
 import android.webkit.ValueCallback;
 //import android.webkit.WebView;
 //import android.webkit.WebViewClient;
-import org.chromium.net.NetError;
 import org.xwalk.core.XWalkResourceClient;
 import org.xwalk.core.XWalkView;
 


### PR DESCRIPTION
Shared mode allows multiple xwalk apps to share one xwalk runtime
library. Each xwalk app is bundled with a reflection layer instead
of the whole runtime library, whereas there is a library apk to be
installed on device for xwalk apps to use.