### PR TITLE
Add a preference to disable immersive mode

### DIFF
--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -228,7 +228,7 @@ public abstract class CordovaActivity extends XWalkActivity implements CordovaIn
         } else if (preferences.getBoolean("Fullscreen", false)) {
             toggleFullscreen(getWindow());
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            if (isImmersiveMode()) {
                 getWindow().getDecorView().setOnSystemUiVisibilityChangeListener(new View.OnSystemUiVisibilityChangeListener() {
                     @Override
                     public void onSystemUiVisibilityChange(int visibility) {
@@ -315,12 +315,17 @@ public abstract class CordovaActivity extends XWalkActivity implements CordovaIn
      */
     @SuppressLint("NewApi")
     private void toggleFullscreen(Window window) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+        if (isImmersiveMode()) {
             setSystemUiVisibilityMode(window);
         } else {
             window.setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
                     WindowManager.LayoutParams.FLAG_FULLSCREEN);
         }
+    }
+
+    private boolean isImmersiveMode() {
+        return !preferences.getBoolean("disableImmersive", false) &&
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
     }
 
     private void setSystemUiVisibilityMode(Window window) {
@@ -1042,7 +1047,7 @@ public abstract class CordovaActivity extends XWalkActivity implements CordovaIn
                 {
                     toggleFullscreen(splashDialog.getWindow());
 
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                    if (isImmersiveMode()) {
                         splashDialog.getWindow().getDecorView().setOnSystemUiVisibilityChangeListener(new View.OnSystemUiVisibilityChangeListener() {
                             @Override
                             public void onSystemUiVisibilityChange(int visibility) {


### PR DESCRIPTION
The fullscreen of Cordova upstream is hide system UI, so the StatusBar
plugin can work finely. But Crosswalk-cordova project is support immersive
fullscreen by default, so add a preference to align with Cordova upstream.

BUG=XWALK-3919