### PR TITLE
fix package name validation

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -158,7 +158,7 @@ function copyScripts(projectPath) {
 function validatePackageName(package_name) {
     //Make the package conform to Java package types
     //Enforce underscore limitation
-    if (!/^[a-zA-Z]+(\.[a-zA-Z0-9][a-zA-Z0-9_]*)+$/.test(package_name)) {
+    if (!/^[a-zA-Z0-9]+(\.[a-zA-Z0-9][a-zA-Z0-9_]*)+$/.test(package_name)) {
         return Q.reject('Package name must look like: com.company.Name');
     }
 


### PR DESCRIPTION
you can see accepted aplications in google play that contain number in the first part of package name, those apps cant be build with crosswalk and intel xdk because of this validation bug\inconsistent with google play. for example this package: http://bit.ly/1aVO6Re