### PR TITLE
Add the interface of canGoBack in CordovaWebView

### DIFF
--- a/framework/src/org/apache/cordova/CordovaWebView.java
+++ b/framework/src/org/apache/cordova/CordovaWebView.java
@@ -516,6 +516,14 @@ public class CordovaWebView extends XWalkView {
         }
     }
 
+    /**
+     * Gets whether this WebView has a back history item.
+     *
+     * @return true if can go back, false if we are already at top
+     */
+    public boolean canGoBack() {
+        return this.getNavigationHistory().canGoBack();
+    }
 
     /**
      * Go to previous page in history.  (We manage our own history)


### PR DESCRIPTION
Newer versions of the splash screen Cordova plugin invoke CordovaWebView's canGoBack(),
which does not exist in our version of it (we invoke XWalkView.getNavigationHistory().canGoBack() instead).
Original report: https://lists.crosswalk-project.org/pipermail/crosswalk-help/2015-February/000845.html.

BUG=XWALK-3612