### PR TITLE
Fix the Cordova app exit issue.

### DIFF
--- a/framework/src/org/apache/cordova/CordovaActivity.java
+++ b/framework/src/org/apache/cordova/CordovaActivity.java
@@ -1115,8 +1115,13 @@ public abstract class CordovaActivity extends XWalkActivity implements CordovaIn
     public boolean onKeyDown(int keyCode, KeyEvent event)
     {
         //Determine if the focus is on the current view or not
-        if (appView != null && appView.getFocusedChild() != null && (keyCode == KeyEvent.KEYCODE_BACK || keyCode == KeyEvent.KEYCODE_MENU)) {
-                    return appView.onKeyDown(keyCode, event);
+        if (appView != null && appView.getFocusedChild() != null &&
+                (keyCode == KeyEvent.KEYCODE_BACK || keyCode == KeyEvent.KEYCODE_MENU)) {
+            if (!appView.onKeyDown(keyCode, event)) {
+                getActivity().finish();
+                return false;
+            }
+            return true;
         }
         else
             return super.onKeyDown(keyCode, event);

--- a/framework/src/org/apache/cordova/CordovaWebView.java
+++ b/framework/src/org/apache/cordova/CordovaWebView.java
@@ -675,13 +675,6 @@ public class CordovaWebView extends XWalkView {
                         return true;
                     }
                     // If not, then invoke default behavior
-                    else {
-                        //this.activityState = ACTIVITY_EXITING;
-                        //return false;
-                        // If they hit back button when app is initializing, app should exit instead of hang until initialization (CB2-458)
-                        this.cordova.getActivity().finish();
-                        return false;
-                    }
                 }
             }
         }


### PR DESCRIPTION
This patch is to fix Cordova app exit issue when the soft keyboard
displaying and press back key.
If the back key was not consumed by CordovaWebView, finish the current
activity, The key up in CordovaWebView was always called with soft keyboard
displaying or not, so adjust the finish() action to CordovaActivity's
onKeyDown().

BUG=XWALK-3915